### PR TITLE
Update to use SPDX licensing expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,7 @@
   "bugs": {
     "url": "https://github.com/jonschlinkert/parse-git-config/issues"
   },
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/jonschlinkert/parse-git-config/blob/master/LICENSE"
-  },
+  "license": "MIT",
   "files": [
     "index.js"
   ],


### PR DESCRIPTION
The previous license expression is no longer valid syntax and has been deprecated.
