### PR TITLE
Shim util.promisify since it doesn't exist prior to Node 8

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,25 @@ const util = require('util');
 const ini = require('ini');
 const configPath = require('git-config-path');
 const expand = require('expand-tilde');
-const read = util.promisify(fs.readFile);
-const stat = util.promisify(fs.stat);
+
+/**
+ * Wraps an arbitrary function in a Promise.
+ *
+ * @param {Function} `func` The function to be wrapped.
+ */
+
+function promisify(func) {
+  return function (...args) {
+    return new Promise((resolve, reject) => {
+      func(...args, (err, res) => {
+        err ? reject(err) : resolve(res);
+      });
+    });
+  }
+}
+
+const read = promisify(fs.readFile);
+const stat = promisify(fs.stat);
 
 /**
  * Asynchronously parse a `.git/config` file. If only the callback is passed,


### PR DESCRIPTION
This change uses the [util.promisify](https://github.com/ljharb/util.promisify) library to polyfill/shim the Node.js API `util.promisify` since it doesn't exist before Node.js 8.  I'm using `parse-git-config` to target an Electron app that hasn't updated to an equivalent version yet.  Let me know if you'd like anything changed!